### PR TITLE
rows/0 should return a list of values per row.

### DIFF
--- a/src/sqerl_transformers.erl
+++ b/src/sqerl_transformers.erl
@@ -53,11 +53,11 @@ rows(none) ->
 rows([]) ->
     {ok, none};
 rows(Result) ->
-    {ok, Result}.
+    {ok, [ [ Val || {_Key, Val} <- Row] || Row <- Result ] }.
 
-rows_as_records(_RecName, _RecordInfo, []) -> 
+rows_as_records(_RecName, _RecordInfo, []) ->
     {ok, none};
-rows_as_records(_RecName, _RecordInfo, none) -> 
+rows_as_records(_RecName, _RecordInfo, none) ->
     {ok, none};
 rows_as_records(RecName, RecordInfo, Rows) ->
     {ok, [ begin

--- a/test/sqerl_transformers_tests.erl
+++ b/test/sqerl_transformers_tests.erl
@@ -82,10 +82,23 @@ first_as_record_test() ->
                             public_key= <<"abcdef0123456789">>}},
                  ChefUserFirstAsRecord(Rows)).
 rows_test() ->
+    Rows = [[{<<"id">>, 123},
+             {<<"authz_id">>, <<"authz_id">>},
+             {<<"username">>, <<"clownco">>},
+             {<<"pubkey_version">>, <<"XXX">>},
+             {<<"public_key">>, <<"abcdef0123456789">>}],
+            [{<<"id">>, 1234},
+             {<<"authz_id">>, <<"authz_id2">>},
+             {<<"username">>, <<"skynet">>},
+             {<<"pubkey_version">>, <<"XXX">>},
+             {<<"public_key">>, <<"9876543210fedcab">>}]],
+
     RowsTransformer = sqerl_transformers:rows(),
 
     ?assertEqual({ok, none}, RowsTransformer([])),
-    ?assertEqual({ok, [foo, bar, baz]}, RowsTransformer([foo, bar, baz])).
+    Results = [[123, <<"authz_id">>, <<"clownco">>, <<"XXX">>, <<"abcdef0123456789">>],
+               [1234, <<"authz_id2">>, <<"skynet">>, <<"XXX">>, <<"9876543210fedcab">>]],
+    ?assertEqual({ok, Results}, RowsTransformer(Rows)).
 
 count_test() ->
     CountTransformer = sqerl_transformers:count(),


### PR DESCRIPTION
Currently it acts like identity/0 and returns a proplist

This changes the behavior of rows - checking existing code rows/0 is not used anywhere right
now so this should not break existing code
