### PR TITLE
Fixup for column_transformers to work with app.config

### DIFF
--- a/src/sqerl_transformers.erl
+++ b/src/sqerl_transformers.erl
@@ -20,6 +20,10 @@
          convert_integer_to_boolean/1,
          by_column_name/2]).
 
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
 -include_lib("eunit/include/eunit.hrl").
 
 rows() ->
@@ -130,8 +134,10 @@ single_column({Name, Data}, Transforms) when is_list(Transforms) ->
     case proplists:get_value(Name, Transforms) of
         undefined ->
             {Name, Data};
-        Transform ->
-            {Name, Transform(Data)}
+        Fun when is_function(Fun) ->
+            {Name, Fun(Data)};
+        {Module, Fun} ->
+            {Name, apply(Module, Fun, [Data])}
     end.
 
 by_column_name(Rows, undefined) ->


### PR DESCRIPTION
- we need to supply functions as {Mod, Fun} tuples and apply/3
  instead of suppling them as funs. We add support for
  specifying a column transformer as either a fun or as {M, F} tuple

Includes itests for sqerl_transformers:single_column dealing with
different transformer configs
