### PR TITLE
Updated itest clean sql to work if test database does not exist.

### DIFF
--- a/itest/itest_mysql_clean.sql
+++ b/itest/itest_mysql_clean.sql
@@ -1,2 +1,2 @@
-drop database itest;
+drop database if exists itest;
 drop user 'itest'@'localhost';

--- a/itest/itest_pgsql_clean.sql
+++ b/itest/itest_pgsql_clean.sql
@@ -1,2 +1,2 @@
-drop database itest;
-drop user itest;
+drop database if exists itest;
+drop user if exists itest;


### PR DESCRIPTION
This can happen if there was an error in setting it up in the first place.
