### PR TITLE
Fix error output in sqerl_mysql_client.

### DIFF
--- a/src/sqerl_mysql_client.erl
+++ b/src/sqerl_mysql_client.erl
@@ -97,7 +97,7 @@ execute(NameOrQuery, Args, #state{cn=Cn}=State) ->
         exit:{_, closed} ->
             {{error, closed}, State};
         Type:Reason ->
-            error_logger:error_msg("sqerl_mysql_client:execute(~p, ~p): ~s:~s~n", [NameOrQuery, Args, Type, Reason]),
+            error_logger:error_msg("sqerl_mysql_client:execute(~p, ~p): ~p~n", [NameOrQuery, Args, {Type, Reason}]),
             exit(Reason)
     end.
 


### PR DESCRIPTION
All tests pass.

...
  itest: basic_test_ (Handles timeout correctly)...
=ERROR REPORT==== 10-Dec-2012::16:14:15 ===
sqerl_mysql_client:execute("select sleep(30)", []): {exit,
                                                     {failed_to_recv_packet_header,
                                                      timeout}}
...
