### PR TITLE
add uuid, uuidarray and varchararray

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -648,7 +648,10 @@ array_test_() ->
       {<<"Insert arrays with statements">>,
        fun insert_direct_array/0},
       {<<"Insert arrays with prepared statements">>,
-       fun insert_array/0}
+       fun insert_array/0},
+      {<<"Insert array of UUIDs">>,
+       fun insert_uuidarray/0}
+
      ]}.
 
 insert_direct_array() ->
@@ -664,11 +667,23 @@ insert_array() ->
     Expected = {ok, [[{<<"insert_users">>, <<>>}]]},
     ?assertMatch(Expected, sqerl:execute(new_users, Data)),
 
+    %% cleanup
     Ok = lists:duplicate(4, {ok, 1}),
     ?assertMatch(Ok, [sqerl:statement(delete_user_by_lname, [LName]) ||
             [_, LName, _, _, _] <- ?NAMES]).
 
-    %% cleanup.
+insert_uuidarray() ->
+    Data = [ [<<"46f16152-6366-4abd-8110-dbd9756bde91">>,
+              <<"733ef125-e115-41e2-a2fb-4fe7fdd84f92">>,
+              <<"52b49b92-0308-46c1-bc15-c657a044f0e3">>] ],
+    Expected = {ok, [[{<<"insert_ids">>, <<>>}]]},
+    ?assertMatch(Expected, sqerl:execute(new_ids, Data)),
+
+    ExpectedData = [[{<<"id">>, <<"46f16152-6366-4abd-8110-dbd9756bde91">>}],
+                    [{<<"id">>, <<"733ef125-e115-41e2-a2fb-4fe7fdd84f92">>}],
+                    [{<<"id">>, <<"52b49b92-0308-46c1-bc15-c657a044f0e3">>}]],
+    ?assertMatch({ok, ExpectedData}, sqerl:execute(<<"SELECT * from uuids">>, [])).
+
 
 to_columns(Rows) ->
     to_columns(Rows, [], [], [], [], []).

--- a/itest/itest_pgsql_create.sql
+++ b/itest/itest_pgsql_create.sql
@@ -53,3 +53,24 @@ END;
 $$
 LANGUAGE plpgsql;
 
+CREATE TABLE uuids (
+       id uuid UNIQUE NOT NULL
+);
+
+GRANT ALL PRIVILEGES ON TABLE uuids TO itest;
+
+CREATE OR REPLACE FUNCTION insert_ids(uuid[])
+RETURNS VOID AS
+$$
+DECLARE
+    i INT4;
+BEGIN
+    FOR i IN SELECT generate_subscripts( $1, 1 )
+    LOOP
+        INSERT INTO uuids (id) VALUES ($1[i]);
+    END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+

--- a/itest/statements_pgsql.conf
+++ b/itest/statements_pgsql.conf
@@ -48,3 +48,8 @@
 {new_users,
  <<"SELECT insert_users($1, $2, $3, $4, $5)">>}.
 
+{new_id,
+ <<"INSERT INTO uuids (id) VALUES($1)">>}.
+
+{new_ids,
+ <<"SELECT insert_ids($1)">>}.


### PR DESCRIPTION
This is a modified sqerl that can use the new features in epgsql around UUID marshalling and support for varchar and UUID arrays.

The only changes here are new tests around this functionality with sqerl.

Note the rebar.config has been changed to point at the epgsql branch and this should be removed before merging to master
