### PR TITLE
Add configurable timeout for epgsql.

### DIFF
--- a/src/sqerl_client.erl
+++ b/src/sqerl_client.erl
@@ -127,6 +127,7 @@ init(DbType) ->
               {user, ev(db_user)},
               {pass, ev(db_pass)},
               {db, ev(db_name)},
+              {timeout, ev(db_timeout, 5000)},
               {idle_check, IdleCheck},
               {prepared_statements, Statements},
               {column_transforms, ev(column_transforms)}],

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -153,9 +153,10 @@ init(Config) ->
     {port, Port} = lists:keyfind(port, 1, Config),
     {user, User} = lists:keyfind(user, 1, Config),
     {pass, Pass} = lists:keyfind(pass, 1, Config),
+    {timeout, Timeout} = lists:keyfind(timeout, 1, Config),
     {db, Db} = lists:keyfind(db, 1, Config),
     {prepared_statements, Statements} = lists:keyfind(prepared_statements, 1, Config),
-    Opts = [{database, Db}, {port, Port}],
+    Opts = [{database, Db}, {port, Port}, {timeout, Timeout}],
     CTrans =
         case lists:keyfind(column_transforms, 1, Config) of
             {column_transforms, CT} -> CT;


### PR DESCRIPTION
Add configurable timeout for epgsql.

The default timeout of epgsql is 5 seconds. This is too short, and longer requests timeout and roll back. This became apparent when trying to delete large organizations with lots of checksums out of sql.

This patch adds a configuration parameter db_timeout to sqerl, with a default value of 5 seconds.
