### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,10 @@
          {git, "git://github.com/opscode/epgsql.git", "master"}},
 
         {pooler, ".*",
-         {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}}]}.
+         {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}},
+        
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+       ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
