### PR TITLE
 Support for INSERT ... RETURNING queries

### DIFF
--- a/include/sqerl.hrl
+++ b/include/sqerl.hrl
@@ -27,5 +27,7 @@
 -type sqerl_rows() :: [sqerl_row()].
 -type sqerl_sql() :: string() | binary().
 -type sqerl_query() :: atom() | sqerl_sql().
--type sqerl_results() :: {ok, integer() | sqerl_rows()} | {error, atom() | tuple()}.
+-type sqerl_results() :: {ok, integer() | sqerl_rows()} |
+                         {ok, integer(), sqerl_rows()} |
+                         {error, atom() | tuple()}.
 

--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -81,6 +81,8 @@ basic_test_() ->
        fun pool_overflow/0},
       {<<"Insert operations">>,
        fun insert_data/0},
+      {"insert returning",
+       fun insert_returning/0},
       {<<"Select operations">>,
        fun select_data/0},
       {<<"Select w/record xform operations">>,
@@ -209,7 +211,13 @@ pool_overflow() ->
 
 insert_data() ->
     Expected = lists:duplicate(4, {ok, 1}),
-    ?assertMatch(Expected, [sqerl:statement(new_user, Name) || Name <- ?NAMES]).
+    ?assertEqual(Expected, [sqerl:statement(new_user, Name) || Name <- ?NAMES]).
+
+insert_returning() ->
+    UserData = ["Free", "Ride", 0, <<"2014-10-03 16:47:46">>, true],
+    {ok, 1, [Data]} = sqerl:select(new_user_returning, UserData),
+    ?assert(is_integer(proplists:get_value(<<"id">>, Data))),
+    ?assertEqual(<<"Free">>, proplists:get_value(<<"first_name">>, Data)).
 
 select_data() ->
     {ok, User} = sqerl:select(find_user_by_lname, ["Smith"], first),
@@ -292,7 +300,7 @@ select_simple() ->
     Sql = <<"select count(*) as num_users from users">>,
     {ok, Rows} = sqerl:execute(Sql),
     [[{<<"num_users">>, NumUsers}]] = Rows,
-    ?assertEqual(4, NumUsers).
+    ?assertEqual(5, NumUsers).
 
 select_simple_with_parameters() ->
     Sql = <<"select id from users where last_name = $1">>,
@@ -305,7 +313,7 @@ select_simple_with_parameters() ->
 %% Tests for adhoc SQL
 %%
 adhoc_select_all() ->
-    ExpectedNumRows = length(?NAMES),
+    ExpectedNumRows = length(?NAMES) + 1,
     {ok, Rows} = sqerl:adhoc_select([<<"*">>], <<"users">>, all),
     ?assertEqual(ExpectedNumRows, length(Rows)).
 
@@ -336,7 +344,7 @@ adhoc_select_equals_str() ->
 adhoc_select_nequals_str() ->
     {ok, Rows} = sqerl:adhoc_select([<<"id">>], <<"users">>,
                                     {<<"last_name">>, nequals, <<"Smith">>}),
-    ExpectedRows = [[{<<"id">>,2}],[{<<"id">>,3}],[{<<"id">>,4}]],
+    ExpectedRows = [[{<<"id">>,2}],[{<<"id">>,3}],[{<<"id">>,4}], [{<<"id">>,5}]],
     ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)).
 
 adhoc_select_nequals_int() ->
@@ -345,7 +353,8 @@ adhoc_select_nequals_int() ->
     ExpectedRows = [
                     [{<<"last_name">>,<<"Presley">>}],
                     [{<<"last_name">>,<<"Anderson">>}],
-                    [{<<"last_name">>,<<"Maier">>}]
+                    [{<<"last_name">>,<<"Maier">>}],
+                    [{<<"last_name">>,<<"Ride">>}]
                    ],
     ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)).
 
@@ -357,7 +366,8 @@ adhoc_select_not() ->
     ExpectedRows = [
                     [{<<"id">>, 2}],
                     [{<<"id">>, 3}],
-                    [{<<"id">>, 4}]
+                    [{<<"id">>, 4}],
+                    [{<<"id">>, 5}]
                    ],
     ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)).
 
@@ -406,7 +416,8 @@ adhoc_select_and() ->
     ExpectedRows = [
                     [{<<"id">>, 2}],
                     [{<<"id">>, 3}],
-                    [{<<"id">>, 4}]
+                    [{<<"id">>, 4}],
+                    [{<<"id">>, 5}]
                    ],
     ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)).
 
@@ -420,7 +431,8 @@ adhoc_select_or() ->
     ExpectedRows = [
                     [{<<"id">>, 2}],
                     [{<<"id">>, 3}],
-                    [{<<"id">>, 4}]
+                    [{<<"id">>, 4}],
+                    [{<<"id">>, 5}]
                    ],
     ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)).
 
@@ -466,7 +478,8 @@ adhoc_select_order_by() ->
                     [{<<"id">>, 1}],
                     [{<<"id">>, 2}],
                     [{<<"id">>, 3}],
-                    [{<<"id">>, 4}]
+                    [{<<"id">>, 4}],
+                    [{<<"id">>, 5}]
                    ],
     ?assertEqual(ExpectedRows, Rows).
 

--- a/itest/statements_pgsql.conf
+++ b/itest/statements_pgsql.conf
@@ -18,6 +18,11 @@
 {new_user,
  <<"INSERT INTO users (first_name, last_name, high_score, created, active) VALUES ($1, $2, $3, $4, $5)">>}.
 
+{new_user_returning,
+<<"INSERT INTO users (first_name, last_name, high_score, created, active)"
+  " VALUES ($1, $2, $3, $4, $5) "
+  "RETURNING id, first_name, last_name, high_score, created, active">>}.
+
 {find_user_by_lname,
  <<"SELECT id, first_name, last_name, high_score, active from users where last_name = $1">>}.
 

--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -95,6 +95,8 @@ select(StmtName, StmtArgs, XformName, XformArgs) ->
             {ok, none};
         {ok, Results} ->
             {ok, Results};
+        {ok, Count, Results} ->
+            {ok, Count, Results};
         {error, Reason} ->
             parse_error(Reason)
     end.
@@ -111,6 +113,8 @@ statement(StmtName, StmtArgs, XformName, XformArgs) ->
             {ok, none};
         {ok, N} when is_number(N) ->
             {ok, N};
+        {ok, N, Rows} when is_number(N) ->
+            {ok, N, Rows};
         {error, Reason} ->
             parse_error(Reason)
     end.
@@ -120,6 +124,11 @@ execute_statement(StmtName, StmtArgs, XformName, XformArgs) ->
         {ok, Results} ->
             Xformer = erlang:apply(sqerl_transformers, XformName, XformArgs),
             Xformer(Results);
+        {ok, Count, Results} ->
+            %% we'll get here for an INSERT ... RETURNING query
+            Xformer = erlang:apply(sqerl_transformers, XformName, XformArgs),
+            {ok, XResult} = Xformer(Results),
+            {ok, Count, XResult};
         Other ->
             Other
     end.

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -110,6 +110,11 @@ execute_prepared({#prepared_statement{} = PrepStmt, Statements}, Parameters,
             Rows = unpack_rows(PrepStmt, RowData),
             TRows = sqerl_transformers:by_column_name(Rows, CTrans),
             {ok, TRows};
+        {ok, Count, RowData} when is_list(RowData), is_integer(Count) ->
+            pgsql:sync(Cn),
+            Rows = unpack_rows(PrepStmt, RowData),
+            TRows = sqerl_transformers:by_column_name(Rows, CTrans),
+            {ok, Count, TRows};
         Other ->
             pgsql:sync(Cn),
             {error, Other}


### PR DESCRIPTION
```
Postgresql allows INSERT queries to return data via RETURNING. This is
especially useful to return values generated by the DB such as sequence
values and time stamps.

This patch introduces a new return type as:

    {ok, Count, Rows}

Providing the return value in this form most closely matches what comes
back from pg. For the happy path case, there's little value in providing
the count as that should match the number of rows returned; an alternate
API would detect this case internally and return it as simply `{ok,
Rows}`. For now, aligning with the data returned by the DB seemed like
the right starting place.
```

ping @opscode/delivery @sdelano 
