### PR TITLE
Fix handling of syntax error in queries

### DIFF
--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -405,7 +405,14 @@ parse_error(pgsql, {error,               % error from sqerl
                     {error,              % error record marker from epgsql
                      _Severity,          % Severity
                      Code, Message, _Extra}}) ->
-    do_parse_error({Code, Message}, ?PGSQL_ERROR_CODES).
+    do_parse_error({Code, Message}, ?PGSQL_ERROR_CODES);
+parse_error(_, Error) ->
+    case Error of
+        {error, _} ->
+            Error;
+        _ ->
+            {error, Error}
+    end.
 
 do_parse_error({Code, Message}, CodeList) ->
     case lists:keyfind(Code, 1, CodeList) of

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -123,9 +123,9 @@ execute_prepared({#prepared_statement{} = PrepStmt, Statements}, Parameters,
             {error, X}
         end,
     {Result, State#state{statements = Statements}};
-execute_prepared(Error, _Parameters, _State) ->
+execute_prepared(Error, _Parameters, State) ->
     %% There was an error preparing the query or the named query was not found.
-    Error.
+    {Error, State}.
 
 
 %% @doc Prepare a new statement.

--- a/test/kitchen.erl
+++ b/test/kitchen.erl
@@ -26,4 +26,7 @@
      {test_query,
       ["SELECT name FROM ",
        "kitchens ",
-       "ORDER BY name"]}].
+       "ORDER BY name"]},
+     {bad_query,
+      ["SELECT name FROM not_a_table"]}
+    ].

--- a/test/sqerl_rec_tests.erl
+++ b/test/sqerl_rec_tests.erl
@@ -114,6 +114,12 @@ kitchen_test_() ->
                K_11_20 = sqerl_rec:fetch_page(kitchen, Next , 10),
                PageNames = [ kitchen:'#get-'(name, K) || K <- (K_1_10 ++ K_11_20) ],
                ?assertEqual(ExpectNames, PageNames)
+       end},
+      {"bad query returns error",
+       fun() ->
+               Error = sqerl:select(kitchen_bad_query, []),
+               Msg = <<"relation \"not_a_table\" does not exist">>,
+               ?assertMatch({error, {syntax, {Msg, _}}}, Error)
        end}
      ]}.
 


### PR DESCRIPTION
The execute_prepared function in sqerl_pgsql_client was not returning
the State record in the final fun head catching unrecognized errors such
as bad queries (either bad syntax or no such table).

In addition, the parse_error function was not flexible enough to allow
these messages through.

ping @christophermaier @jamesc 
