### PR TITLE
fix dup queries

### DIFF
--- a/test/cook.erl
+++ b/test/cook.erl
@@ -42,6 +42,13 @@
 
 '#statements'() ->
     [default,
+     {insert2,
+      ["INSERT INTO cookers (kitchen_id, name) "
+       "SELECT k.id, $2 FROM kitchens AS k "
+       "WHERE k.name = $1 RETURNING "
+       "id, kitchen_id, name, auth_token, "
+       "auth_token_bday, ssh_pub_key, "
+       "first_name, last_name, email"]},
      {fetch_by_name_kitchen_id,
       sqerl_rec:gen_fetch(cook, [name, kitchen_id])}].
 

--- a/test/spoon.erl
+++ b/test/spoon.erl
@@ -1,0 +1,28 @@
+-module(spoon).
+-behaviour(sqerl_rec).
+
+-export([
+         '#insert_fields'/0,
+         '#update_fields'/0,
+         '#statements'/0
+        ]).
+
+-compile({parse_transform, exprecs}).
+-export_records([spoon]).
+
+-record(spoon, {
+          id,
+          name
+         }).
+
+'#insert_fields'() ->
+    [name].
+
+'#update_fields'() ->
+    [name].
+
+'#statements'() ->
+    [default,
+     {fetch_by_id, "SELECT 'testing' FROM spoons"},
+     {['delete_by_', 'id'], "DELETE FROM spoons WHERE name = 'testing'"}
+    ].


### PR DESCRIPTION
Fix duplication of queries in sqerl_rec
- The default query definition contained a bug in which the
  fetch_by_FirstField query was specified twice.
- Default and custom query merging was broken. First, the merge was
  happening before the query names were normalized via
  join_atoms. Secondly, keymerge was being used instead of ukeymerge and
  thus duplicates were being kept (though the order was such that the
  desired behavior was achieved in terms of custom queries overriding
  defaults).

Add more detail to sqerl_rec error messages

When qfetch doesn't get data, but gets a count, include the count in the
error tuple. Organize the error so that it is a bit easier to match on
if desired. Similarly, for the scalar_fetch error.
