### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: erlang
+otp_release:
+  - R16B03-1
+  - R16B03
+  - R16B02
+  - R16B01
+script: "rm -fr deps && make all"

--- a/concrete.mk
+++ b/concrete.mk
@@ -80,7 +80,7 @@ endif
 
 ~/.dialyzer_plt:
 	@echo "ERROR: Missing ~/.dialyzer_plt. Please wait while a new PLT is compiled."
-	dialyzer --build_plt --apps $(ERLANG_DIALYZER_APPS)
+	dialyzer --build_plt --apps $(ERLANG_DIALYZER_APPS) | fgrep -v dialyzer.ignore
 	@echo "now try your build again"
 
 doc:

--- a/dialyzer.ignore
+++ b/dialyzer.ignore
@@ -1,0 +1,1 @@
+eunit_test.erl:.+: Call to missing or unexported function eunit_test:nonexisting_function/0


### PR DESCRIPTION
This adds support for buildin sqerl on Travis CI, key notes:
- Currently, we only support > R16B01 (R16 fails to build due to
  timeout). We have another PR out for R17/17.0 support
- We needed to add a dialyzer.ignore file (and hook it up in
  concrete) in order to avoid breaking on a eunit dialyzer warning
  that is inconsequential.
