### PR TITLE
This adds support for Erlang 17.0 and turns on itest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: erlang
 otp_release:
+  - 17.0
   - R16B03-1
   - R16B03
   - R16B02
   - R16B01
+  - R15B03
 script: "rm -fr deps && make all"

--- a/concrete.mk
+++ b/concrete.mk
@@ -35,7 +35,7 @@ ERLANG_DIALYZER_APPS = asn1 \
                        webtool \
                        xmerl
 
-all: .concrete/DEV_MODE compile eunit dialyzer $(ALL_HOOK)
+all: .concrete/DEV_MODE compile eunit dialyzer itest $(ALL_HOOK)
 
 .concrete/DEV_MODE:
 	@mkdir -p .concrete

--- a/include/sqerl.hrl
+++ b/include/sqerl.hrl
@@ -30,3 +30,9 @@
 -type sqerl_results() :: {ok, integer() | sqerl_rows()} |
                          {ok, integer(), sqerl_rows()} |
                          {error, atom() | tuple()}.
+
+-ifdef(namespaced_types).
+-type sqerl_dict() :: dict:dict().
+-else.
+-type sqerl_dict() :: dict().
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,15 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{erl_opts, [debug_info, warnings_as_errors]}.
+
+%% Type spec dict() is deprecated in R17 to be removed in R18 in
+%% preference for dict:dict(). But the fix is not compatible with <=
+%% R16.
+{erl_opts,
+    [{platform_define, "^[0-9]+", namespaced_types},
+     debug_info,
+     warnings_as_errors,
+     inline]}.
+
 {erl_first_files, ["src/sqerl_client.erl"]}.
 
 {deps, [
@@ -9,7 +18,7 @@
          {git, "git://github.com/opscode/epgsql.git", "master"}},
 
         {pooler, ".*",
-         {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}},
+         {git, "git://github.com/seth/pooler.git", {tag, "1.1.0"}}},
 
         {envy, ".*",
          {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}


### PR DESCRIPTION
This includes:

```
* Bump pooler to version that supports Erlang 17.0
* Updates for R17 deprecation compatibility while maintaining
  backwards compatibility with R16 and R15
* Adds R15B03 to the Travis build list to verify it works
* Adds the itest target to the all make target to ensure integration
  tests are run as part of a fuill build
```
