### PR TITLE
Stop MySQL before build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ otp_release:
   - R16B02
   - R16B01
   - R15B03
+before_script:
+  - sudo service mysql stop
 script: "rm -fr deps && make all"


### PR DESCRIPTION
The CI build for sqerl is a bit flakey likely due to the excesssive
consumption of memory by dialyzer. Some specifics can be found here:

https://github.com/travis-ci/travis-ci/issues/1409
http://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error

This patch stops MySQL (not used by sqerl) before running tests in
hopes it will reduce the amount of flake in the build. This unfortunately
is not guaranteed to solve the problem, but should at least help a
little.

After this is in, if there are still issues, we may try to see if the
nice folks at Travis CI would be willing to increase our maximum
allocated memory of 3GB.
