### PR TITLE
Sqerl needs Envy.

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -61,7 +61,7 @@ setup_env() ->
                   {init_count, 1},
                   {start_mfa, {sqerl_client, start_link, []}}],
     ok = application:set_env(pooler, pools, [PoolConfig]),
-    Apps = [crypto, asn1, public_key, ssl, epgsql, pooler],
+    Apps = [crypto, asn1, public_key, ssl, envy, epgsql, pooler],
     [ application:start(A) || A <- Apps ].
 
 statements() ->

--- a/src/sqerl.app.src
+++ b/src/sqerl.app.src
@@ -26,6 +26,7 @@
   {applications, [kernel,
                   stdlib,
                   crypto,
+                  envy,
                   epgsql,
                   pooler]}
  ]}.


### PR DESCRIPTION
It seems like the apps that use sqerl already have envy coincidentally,
but we need it explicitly.
