### PR TITLE
Revert "Sqerl needs Envy."

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -61,7 +61,7 @@ setup_env() ->
                   {init_count, 1},
                   {start_mfa, {sqerl_client, start_link, []}}],
     ok = application:set_env(pooler, pools, [PoolConfig]),
-    Apps = [crypto, asn1, public_key, ssl, envy, epgsql, pooler],
+    Apps = [crypto, asn1, public_key, ssl, epgsql, pooler],
     [ application:start(A) || A <- Apps ].
 
 statements() ->

--- a/src/sqerl.app.src
+++ b/src/sqerl.app.src
@@ -26,7 +26,6 @@
   {applications, [kernel,
                   stdlib,
                   crypto,
-                  envy,
                   epgsql,
                   pooler]}
  ]}.


### PR DESCRIPTION
Reverts opscode/sqerl#70

There are some complications to just including envy in the app.src. While it solves the problem for relx builds, it there are other scenarios in which it breaks things. Now that I'm aware of these, I'll be able to test them with any future fix.
