### PR TITLE
Jc/ca 531/timestamp transformers

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -27,7 +27,7 @@
 
 -define(GET_ARG(Name, Args), proplists:get_value(Name, Args)).
 -define(NAMES, [["Kevin", "Smith", 666, <<"2011-10-01 16:47:46">>, true],
-                ["Mark", "Anderson", 42, <<"2011-10-02 16:47:46">>, true],
+                ["Mark", "Anderson", 42, <<"2011-10-02 16:11:46">>, true],
                 ["Chris", "Maier", 0, <<"2011-10-03 16:47:46">>, true],
                 ["Elvis", "Presley", 16, <<"2011-10-04 16:47:46">>, false]]).
 -define(POOL_NAME, sqerl).
@@ -273,7 +273,7 @@ update_created() ->
                       "Smith"])),
     ?assertMatch({ok, 1},
                  sqerl:statement(update_created_by_lname,
-                     [{{2011, 11, 2}, {16, 47, 46}}, "Anderson"])),
+                     [{{2011, 11, 2}, {16, 11, 46}}, "Anderson"])),
     ?assertMatch({ok, 1},
                  sqerl:statement(update_created_by_lname,
                      [<<"2011-11-03 16:47:46">>, "Maier"])),
@@ -281,7 +281,7 @@ update_created() ->
     {ok, User1} = sqerl:select(find_created_by_lname, ["Smith"], first_as_scalar, [created]),
     ?assertMatch({datetime, {{2011, 11, 01}, {16, 47, 46}}}, User1),
     {ok, User2} = sqerl:select(find_created_by_lname, ["Anderson"], first_as_scalar, [created]),
-    ?assertMatch({datetime, {{2011, 11, 02}, {16, 47, 46}}}, User2),
+    ?assertMatch({datetime, {{2011, 11, 02}, {16, 11, 46}}}, User2),
     {ok, User3} = sqerl:select(find_created_by_lname, ["Maier"], first_as_scalar, [created]),
     ?assertMatch({datetime, {{2011, 11, 03}, {16, 47, 46}}}, User3).
 

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -372,8 +372,6 @@ extract_column_names({prepared_column_data, ColumnData}) ->
 %%%
 %%% Simple hooks to support coercion inputs to match the type expected by pgsql
 %%%
-transform(timestamp, {{_Y, _M, _D}, {_H, _M, _S}}=TS) ->
-    sqerl_transformers:convert_YMDHMS_tuple_to_datetime(TS);
 transform(timestamp, {datetime, X}) ->
     X;
 transform(timestamp, X) when is_binary(X) ->


### PR DESCRIPTION
Epgsql expects a timestamp to come an erlang_time() tuple.  This
transform was converting that to an invalid tagged-tuple of form
{datetime, erlang_time()}.

There was a bug in the transform (using _M for both month and minute) that
 meant it only pattern matched on certain cases (when month == minute) meaning
it appeared as an intermittent error, causing a badmatch in pgsql
pgsql_idatetime:date2j/1.

This PR just removes the bad transform completely since it's the
wrong thing to do.

cc @PrajaktaPurohit , @seth 
