### PR TITLE
increase undef filtering coverage

### DIFF
--- a/src/sqerl_rec.erl
+++ b/src/sqerl_rec.erl
@@ -127,7 +127,8 @@
 -spec qfetch(atom(), atom_list(), [any()]) -> [db_rec()] | {error, _}.
 qfetch(RecName, Query, Vals) ->
     RealQ = join_atoms([RecName, '_', Query]),
-    case sqerl:select(RealQ, Vals) of
+    CleanVals = [undef_to_null(V) || V <- Vals],
+    case sqerl:select(RealQ, CleanVals) of
         {ok, none} ->
             [];
         {ok, N} when is_integer(N) ->
@@ -267,7 +268,7 @@ delete(Rec, By) ->
 
 rec_to_vlist(Rec, Fields) ->
     RecName = rec_name(Rec),
-    [ undef_to_null(RecName:getval(F, Rec)) || F <- Fields ].
+    [ RecName:getval(F, Rec) || F <- Fields ].
 
 %% we translate `undefined' properties to `null' so that
 %% they get saved as `NULL' in the DB, and not `"undefined"'

--- a/test/sqerl_rec_tests.erl
+++ b/test/sqerl_rec_tests.erl
@@ -291,6 +291,30 @@ cook_test_() ->
                                              [<<"no such kitchen">>,
                                               <<"sam">>]))
        end},
+      {"qfetch insert undefineds sanitized",
+       fun() ->
+               {K0, _KName} = make_kitchen(<<"no such kitchen">>),
+               [K1] = sqerl_rec:insert(K0),
+               KitchenId = kitchen:getval(id, K1),
+               [C] = sqerl_rec:qfetch(cook, insert,
+                                      [KitchenId,
+                                       make_name(<<"asm">>),
+                                       <<"asdsasd">>,
+                                       <<"NONE">>,
+                                       <<"">>,
+                                       undefined,
+                                       <<"">>
+                                      ]),
+               %% make sure we can insert via raw qfetch
+               ?assertMatch(cook, element(1, C)),
+
+               %% make sure that undefineds aren't coming back as
+               %% literal binaries
+               Name = cook:getval(name, C),
+               [FetchedCook] = sqerl_rec:qfetch(cook, fetch_by_name_kitchen_id,
+                                                [Name, KitchenId]),
+               ?assertEqual(undefined, cook:getval(last_name, FetchedCook))
+       end},
        {"undefined record properties get translated to NULL, and back",
         fun() ->
                 {K0, _KName} = make_kitchen(<<"null-test">>),


### PR DESCRIPTION
since some code calls `sqerl_rec:qfetch/3` directly, we need to filter
the query values there instead of in `rec_to_vlist/2`.
