### PR TITLE
remove inline directive from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,7 @@
 {erl_opts,
     [{platform_define, "^[0-9]+", namespaced_types},
      debug_info,
-     warnings_as_errors,
-     inline]}.
+     warnings_as_errors]}.
 
 {erl_first_files, ["src/sqerl_client.erl"]}.
 


### PR DESCRIPTION
automatically inlining breaks tracing and hot code reloading
sometimes. we should avoid doing it as a blanket action and only inline
in modules where we know that it's performance critical that we do so.
