### PR TITLE
Updated Sqerl for latest epgsql/epgsql

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
         %% This is until a patch of ours gets merged into the main epgsql repo
         {epgsql, ".*",
-         {git, "git://github.com/opscode/epgsql.git", "master"}},
+         {git, "git://github.com/epgsql/epgsql.git", "master"}},
 
         {pooler, ".*",
          {git, "git://github.com/seth/pooler.git", {tag, "1.3.3"}}},

--- a/src/sqerl_client.erl
+++ b/src/sqerl_client.erl
@@ -67,7 +67,7 @@
 
 -record(state, {cb_mod,
                 cb_state,
-                timeout}).
+                timeout = 5000 :: pos_integer()}).
 
 %% behavior callback definitions
 -callback init(Config :: [{atom(), term()}]) ->
@@ -137,9 +137,8 @@ init(CallbackMod) ->
               {column_transforms, envy:get(sqerl, column_transforms, list)}],
     case CallbackMod:init(Config) of
         {ok, CallbackState} ->
-            Timeout = IdleCheck,
             {ok, #state{cb_mod=CallbackMod, cb_state=CallbackState,
-                        timeout=Timeout}, Timeout};
+                        timeout=IdleCheck}, IdleCheck};
         Error ->
             {stop, Error}
     end.

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -93,7 +93,6 @@ execute(SQL, Parameters, #state{cn=Cn}=State) when is_binary(SQL) ->
         {error, ?EPGSQL_TIMEOUT_ERROR} ->
             {{error, timeout}, State};
         {error, Error} ->
-            io:format("Error, ~p", [Error]),
             {{error, Error}, State}
     end;
 %% Prepared statement execution

--- a/src/sqerl_pgsql_errors.erl
+++ b/src/sqerl_pgsql_errors.erl
@@ -20,12 +20,16 @@
 %% @doc Translates Postgres error codes into human-friendly error tuples
 -module(sqerl_pgsql_errors).
 
+-include_lib("epgsql/include/pgsql.hrl").
+
 -export([translate/1,
          translate_code/1]).
 
 %% Error codes taken from http://www.postgresql.org/docs/9.1/static/errcodes-appendix.html
 
--spec translate({error, binary()} | term()) -> {error, atom()} | term().
+-spec translate(#error{} | {error, binary()} | term()) -> {error, atom()} | term().
+translate(#error{code=Code}=_Error) ->
+    translate({error, Code});
 translate({error, Code}) when is_binary(Code) ->
     {error, {Code, translate_code(Code)}};
 translate(Error) ->


### PR DESCRIPTION
The PR You've ALL been waiting for.

* Updated `rebar.config` to use [epgsql/epgsql](https://github.com/epgsql/epgsql)
* Updated error code reporting to use epgsql's error type
* epgsql doesn't *yet* support query timeouts, so using a suggestion from their mailing list, call `set statement_timeout=$default` before every query.

*FUTURE WORK*
Now that each query sets a timeout to the default value, we can add versions that let you specify the timeout you want for a specific query. The goal of this PR was parity with the [wg/epgsql](https://github.com/wg/epgsql) functionality, which has been achieved. (except on connection times, but you can't have it all, Veruca)


